### PR TITLE
Fix failure to set error log path in SPForm snippet.

### DIFF
--- a/core/components/spform/spform.inc.php
+++ b/core/components/spform/spform.inc.php
@@ -135,7 +135,7 @@ global $modx;
 $spfconfig = $scriptProperties;
 $spfconfig['spformPath'] = $modx->getOption('spformPath',$spfconfig,$modx->getOption('core_path').'components/spform/');
 
-ini_set('error_log', $spformPath . 'error.log');
+ini_set('error_log', $spconfig['spformPath'] . 'error.log');
 
 
 $language = !empty($spfconfig['language'])


### PR DESCRIPTION
Also fixes a PHP notice-level error caused by a reference to the nonexistent variable `$spformPath`.
